### PR TITLE
pass table to post create hooks

### DIFF
--- a/src/Scaffold/MigrationCreator.php
+++ b/src/Scaffold/MigrationCreator.php
@@ -31,7 +31,7 @@ class MigrationCreator extends BaseMigrationCreator
 
         $this->files->put($path, $this->populateStub($name, $stub, $table));
 
-        $this->firePostCreateHooks();
+        $this->firePostCreateHooks($table);
 
         return $path;
     }


### PR DESCRIPTION
This is needed as the MigrationCreator from Laravel has been updated and the scaffold option is throwing a warning because of it