### PR TITLE
Added posibility to have your own stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ $ php artisan admin:import helpers
 
 See [wiki](http://laravel-admin.org/docs/#/en/extension-helpers?id=helpers)
 
+## Scaffold templates (stubs)   
+Copy `src/Scaffold/stubs` to your project `app/stubs` and add to your `.env` file:
+```
+ADMIN_STUBS_DIR=/app/stubs/
+```
+
 ## Donate
 
 > Help keeping the project development going, by donating a little. Thanks in advance.

--- a/src/Scaffold/ControllerCreator.php
+++ b/src/Scaffold/ControllerCreator.php
@@ -123,6 +123,7 @@ class ControllerCreator
      */
     public function getStub()
     {
-        return __DIR__.'/stubs/controller.stub';
+        return (getenv("ADMIN_STUBS_DIR") || __DIR__.'/stubs/'). 'controller.stub';
+
     }
 }

--- a/src/Scaffold/MigrationCreator.php
+++ b/src/Scaffold/MigrationCreator.php
@@ -27,7 +27,7 @@ class MigrationCreator extends BaseMigrationCreator
 
         $path = $this->getPath($name, $path);
 
-        $stub = $this->files->get(__DIR__.'/stubs/create.stub');
+        $stub = $this->files->get((getenv("ADMIN_STUBS_DIR") || __DIR__.'/stubs/'). 'create.stub');
 
         $this->files->put($path, $this->populateStub($name, $stub, $table));
 

--- a/src/Scaffold/ModelCreator.php
+++ b/src/Scaffold/ModelCreator.php
@@ -233,6 +233,6 @@ class ModelCreator
      */
     public function getStub()
     {
-        return __DIR__.'/stubs/model.stub';
+        return (getenv("ADMIN_STUBS_DIR") || __DIR__.'/stubs/'). 'model.stub';
     }
 }


### PR DESCRIPTION
There is no way right now to have your own templates of the generated from the scaffold generated controller, model and migration. When the folder of the stubs can be changed from the env everyone can have project-dependent templates of this files