### PR TITLE
Set default value for $lastOrder

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -41,7 +41,7 @@ class Helpers extends Extension
 
     public static function import()
     {
-        $lastOrder = Menu::max('order');
+        $lastOrder = Menu::max('order') ?: 0;
 
         $root = [
             'parent_id' => 0,


### PR DESCRIPTION
在 `admin_menu` 表为空的时候 `Menu::max('order')` 会返回 `null`
此时 `$lastOrder++` 同样会是 `null`, 会导致新增数据失败:
```
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'order' cannot be null (SQL: insert into `admin_menu` (`parent_id`, `order`, `title`, `icon`, `uri`, `
updated_at`, `created_at`) values (0, ?, Helpers, fas fa-cogs, , 2021-08-20 11:28:45, 2021-08-20 11:28:45))
```